### PR TITLE
Add myanon to De-Identification and Anonymization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The potential for models to leak details from the data on which they’re traine
 * [Data Anonymizer Extension for PostgreSQL](https://pgxn.org/dist/postgresql_anonymizer/0.0.3/) - A set of SQL functions that remove personally identifiable values from a PostgreSQL table and replace them with random-but-plausible values.
 * [Anonimatron](https://realrolfje.github.io/anonimatron/) - Free, extendable, open source data anonymization tool.
 * [Anonymizer MySQL](https://www.npmjs.com/package/anonymizer-mysql) - This simple tool will allow you to make anonymizerd clone of your database.
+* [myanon](https://github.com/ppomes/myanon) - A streaming anonymizer for MySQL dump files. Reads mysqldump from stdin and writes an anonymized version to stdout. Supports deterministic hashing, fixed values, JSON field anonymization, and Python extensions.
 * [MySQL Data Anonymizer](https://github.com/globalis-ms/mysql-data-anonymizer) - MySQL Data Anonymizer is a PHP library that anonymizes your data in the database.
 * [Anonymizer](https://github.com/DivanteLtd/anonymizer) - Anonymizer is a universal tool to create anonymized DBs for projects.
 * [anonymize-it](https://github.com/elastic/anonymize-it) - The Elastic Machine Learning Team's general purpose tool for suppression, masking, and generalization of fields to aid data pseudonymization.


### PR DESCRIPTION
[myanon](https://github.com/ppomes/myanon) is a streaming anonymizer for MySQL dump files. It reads mysqldump from stdin and writes an anonymized version to stdout.

Key features:
- Deterministic hashing (HMAC-SHA256) preserving referential integrity
- Built-in rules: texthash, emailhash, inthash, fixed values, substrings
- JSON field anonymization
- Python extensions (e.g., Faker)
- Written in C, single binary, also available as Docker image

Website: https://myanon.io