### PR TITLE
Add Purfect Shield — AI prompt privacy proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 * [Octopii](https://github.com/redhuntlabs/Octopii) - Octopii is an open-source AI-powered PII scanner that can look for image assets such as Government IDs, passports, photos and signatures in a directory.
 * [Data Profiler](https://github.com/capitalone/DataProfiler) - DataProfiler is a Python library created by Capital One to make data analysis, monitoring, and sensitive data detection easy.
 * [PII Catcher](https://github.com/tokern/piicatcher) - Scan databases and data warehouses for PII data. Tag tables and columns in data catalogs like Amundsen and Datahub.
+* [Purfect Shield](https://github.com/purfect-labs/purfect-ai) - An open-source local proxy that tokenizes PII, secrets, and PHI from AI prompts before they reach external LLM providers. Real-time privacy gate for ChatGPT, Claude, Copilot, and 20+ other AI tools. HIPAA, GDPR, and SOC 2 compliance mappings included.
 
 ### Privacy Tech Series by [Lea Kissner](https://twitter.com/leakissner?lang=en)
 ---


### PR DESCRIPTION
Add [Purfect Shield](https://purfect.ai/shield) to the privacy tools section.

Purfect Shield is a privacy engineering tool that prevents PII, PHI, and other sensitive data from being sent to external LLM providers. It sits as a local proxy between users and AI tools (ChatGPT, Claude, Copilot, etc.) and tokenizes sensitive values before they leave the machine — functioning as a privacy gate for the fastest-growing data exfiltration vector: AI prompts.

Unlike PII Catcher or DataProfiler (which scan for PII in databases), Shield operates in real-time at the prompt level, preventing data from ever reaching third-party AI providers.

- Client-side tokenization — data never leaves the machine in plaintext
- Supports 20+ AI tools used daily by developers, analysts, and clinicians
- HIPAA, GDPR, SOC 2 compliance mappings
- Interactive demo at https://purfect.ai/learn/llm-data-redaction
- Open source at https://github.com/purfect-labs/purfect-ai